### PR TITLE
print instead of fatalError if PHManager is not configured

### DIFF
--- a/Sources/ProductHunt/PHManager.swift
+++ b/Sources/ProductHunt/PHManager.swift
@@ -68,7 +68,8 @@ public class PHManager: NSObject, SFSafariViewControllerDelegate {
 
     @objc private func fetchVotesCount() {
         guard let post = post, let token = token else {
-            fatalError("PHManager instance has not been configured.")
+            print("PHManager instance has not been configured.")
+            return
         }
         
         guard let url = URL(string: "https://api.producthunt.com/v2/api/graphql") else {


### PR DESCRIPTION
Hi! Loving this package.

Stumbled upon one thing when implementing in one of my apps: since it's not yet live on ProductHunt, I'm using my backend to fetch the slug (to determine if I need to show the button or no). So until the product is live on PH, there is no `PHPost` configured. Hence, the app crashes when `fetchVotesCount` is called. I think what I'm trying to achieve is a valid use case, and so the print instead of `fatalError` would be appropriate here.

Cheers!